### PR TITLE
Fixes and refinements

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,21 @@
 FROM ubuntu:trusty
 MAINTAINER Kamil Trzciński <ayufan@ayufan.eu>
 
-RUN apt-get update -y
-RUN apt-get install -y openjdk-7-jre-headless
-RUN apt-get install -y wget
-RUN apt-get install -y git-core
-RUN apt-get install -y fakeroot
+ENV DEBIAN_FRONTEND noninteractive
+ENV DEBIAN_PRIORITY critical
+ENV DEBCONF_NOWARNINGS yes
+
+RUN apt-get update \
+    && apt-get upgrade
+RUN apt-get install -y \
+    tzdata-java \
+    openjdk-7-jre-headless \
+    wget \
+    git-core \
+    fakeroot
 
 RUN adduser --home /jenkins --disabled-login --gecos 'Jenkins' jenkins
-RUN # Thu Oct  9 22:52:25 CEST 2014
+
 RUN wget -O /jenkins.war http://mirrors.jenkins-ci.org/war-stable/latest/jenkins.war
 
 USER jenkins

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ ENV DEBIAN_PRIORITY critical
 ENV DEBCONF_NOWARNINGS yes
 
 RUN apt-get update \
-    && apt-get upgrade
+    && apt-get upgrade -y
 RUN apt-get install -y \
     tzdata-java \
     openjdk-7-jre-headless \


### PR DESCRIPTION
Some of this was required for me to get the container to build, and some is arguably stylistic preference.  Merge as you see fit.

Adding the txdata-java and I think the apt-get upgrade are required, though I'm not sure about the latter as local issue was also causing problems.  Good practice anyway.

While not always needed, the non-interactive debian build flags are generally a good idea for debian and ubuntu based containers.

I removed a comment that made little sense, and presumably introduces a redundant layer.  Maybe it's to do with forcing a reload of the jenkins file though?  If so, it seems there should be a better way to do that, even if it's just combining the change into the same `RUN` directive as the download.

I also combined some of the apt-get commands into fewer `RUN` directives.  Again, it reduces the number of file system layers required.